### PR TITLE
fix(conversion): correct LaTeX handling for absolute values PD-3180

### DIFF
--- a/src/data/usecases/mathml-to-latex-convertion/converters/mo.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mo.ts
@@ -5,7 +5,9 @@ import {
   HashUTF8ToLtXConverter,
   allMathOperatorsByChar,
   allMathOperatorsByGlyph,
-  mathNumberByGlyph, allMathOperatorsByGlyphSpecial, mathNumberByGlyphSpecial,
+  mathNumberByGlyph,
+  allMathOperatorsByGlyphSpecial,
+  mathNumberByGlyphSpecial,
 } from '../../../../syntax';
 
 export class MO implements ToLaTeXConverter {
@@ -18,6 +20,13 @@ export class MO implements ToLaTeXConverter {
   convert(): string {
     const normalizedValue = normalizeWhiteSpaces(this._mathmlElement.value);
     const trimmedValue = normalizedValue.trim();
+
+    if (this._mathmlElement.attributes['data-mjx-texclass'] === 'OPEN' && trimmedValue === '|') {
+      return `\\left|`;
+    }
+    if (this._mathmlElement.attributes['data-mjx-texclass'] === 'CLOSE' && trimmedValue === '|') {
+      return `\\right|`;
+    }
 
     return Operator.operate(trimmedValue);
   }


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3180

Ensure correct LaTeX delimiter handling for absolute values, PD-3180:

Correct handling of '|', translating to '\\left|' and '\\right|' based on 'data-mjx-texclass' attributes. 